### PR TITLE
dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+*.md
+.git


### PR DESCRIPTION
This pull request includes changes to the `.dockerignore` file to improve the efficiency of the Docker build process by excluding unnecessary files and directories.

Changes to `.dockerignore`:

* Added `node_modules` to exclude the directory containing Node.js dependencies.
* Added `dist` to exclude the directory containing build artifacts.
* Added `*.log` to exclude log files.
* Added `*.md` to exclude markdown files.
* Added `.git` to exclude the Git directory.