### PR TITLE
Add Swagger API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,13 @@ Open your browser or use a tool like `curl` or `Postman` to access the endpoint:
 ```
 http://localhost:3000/
 ```
+
+## API Documentation
+
+The API documentation is available at the `/docs` endpoint. You can access it by opening your browser and navigating to:
+
+```
+http://localhost:3000/docs
+```
+
+The documentation includes information about the available endpoints, request/response formats, and other details to help you interact with the API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.0.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -1808,6 +1809,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+      "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.1.tgz",
@@ -2229,6 +2236,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.0.7.tgz",
@@ -2348,6 +2375,39 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.0.3.tgz",
+      "integrity": "sha512-oyrhrAzVJz1wYefIYDb6Y0f1VYb8BtYxEI7Ex0ApoUsfGZThyhW9elYANcfBXVaTmICrU8lCESF2ygF6s0ThIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.0",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.18.2"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.0.7.tgz",
@@ -2442,6 +2502,13 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -3928,7 +3995,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -7739,7 +7805,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7913,7 +7978,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -10031,6 +10095,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
+      "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.0.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { ConsoleLogger } from '@nestjs/common';
 import { AppModule } from './app.module';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule, {
@@ -9,6 +10,15 @@ async function bootstrap() {
             colors: true,
         }),
     });
+
+    const config = new DocumentBuilder()
+        .setTitle('API Documentation')
+        .setDescription('The API description')
+        .setVersion('1.0')
+        .build();
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('docs', app, document);
+
     await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
Fixes #10

Add Swagger API documentation setup.

* **Swagger Setup in `src/main.ts`**
  - Import `SwaggerModule` and `DocumentBuilder` from `@nestjs/swagger`.
  - Create Swagger options using `DocumentBuilder`.
  - Create Swagger document using `SwaggerModule.createDocument`.
  - Setup Swagger module using `SwaggerModule.setup` with `/docs` endpoint.

* **Update `README.md`**
  - Add section for API documentation.
  - Include information about accessing the API documentation at `/docs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/first_hng_task/pull/12?shareId=6f23447f-0920-4599-b0b6-228c588b2def).