### PR TITLE
Remove milliseconds from current_time value

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -19,6 +19,9 @@ describe('AppController', () => {
             const response = appController.getHello();
             expect(response).toHaveProperty('email', 'stationphast@gmail.com');
             expect(response).toHaveProperty('current_time');
+            expect(response.current_time).toMatch(
+                /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+            );
             expect(response).toHaveProperty(
                 'github_url',
                 'https://github.com/Phastboy/first_hng_task',

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -7,11 +7,6 @@ export class AppController {
 
     @Get()
     getHello(): { email: string; current_time: string; github_url: string } {
-        const current_time = new Date().toISOString().split('.')[0] + 'Z';
-        return {
-            email: 'stationphast@gmail.com',
-            current_time,
-            github_url: 'https://github.com/Phastboy/first_hng_task',
-        };
+        return this.appService.getHello();
     }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -7,7 +7,7 @@ export class AppController {
 
     @Get()
     getHello(): { email: string; current_time: string; github_url: string } {
-        const current_time = new Date().toISOString();
+        const current_time = new Date().toISOString().split('.')[0] + 'Z';
         return {
             email: 'stationphast@gmail.com',
             current_time,

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class AppService {
     getHello(): { email: string; current_time: string; github_url: string } {
-        const current_time = new Date().toISOString();
+        const current_time = new Date().toISOString().split('.')[0] + 'Z';
         return {
             email: 'stationphast@gmail.com',
             current_time,

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -26,6 +26,9 @@ describe('AppController (e2e)', () => {
                     'stationphast@gmail.com',
                 );
                 expect(res.body).toHaveProperty('current_time');
+                expect(res.body.current_time).toMatch(
+                    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
+                );
                 expect(res.body).toHaveProperty(
                     'github_url',
                     'https://github.com/Phastboy/first_hng_task',


### PR DESCRIPTION
Fixes #15

Remove milliseconds from `current_time` value in the response.

* **src/app.controller.ts**
  - Modify the `current_time` value to exclude milliseconds using `toISOString().split('.')[0] + 'Z'`.

* **src/app.service.ts**
  - Modify the `current_time` value to exclude milliseconds using `toISOString().split('.')[0] + 'Z'`.

* **src/app.controller.spec.ts**
  - Update the test to expect the `current_time` value without milliseconds.
  - Use a regular expression to match the `current_time` value without milliseconds.

* **test/app.e2e-spec.ts**
  - Update the test to expect the `current_time` value without milliseconds.
  - Use a regular expression to match the `current_time` value without milliseconds.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/first_hng_task/pull/16?shareId=fde3f177-1bbd-4ba3-8251-5e78ba813f3e).