### PR TITLE
Fix response

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -18,8 +18,8 @@ describe('AppController', () => {
         it('should return the correct JSON response', () => {
             const response = appController.getHello();
             expect(response).toHaveProperty('email', 'stationphast@gmail.com');
-            expect(response).toHaveProperty('current_time');
-            expect(response.current_time).toMatch(
+            expect(response).toHaveProperty('current_datetime');
+            expect(response.current_datetime).toMatch(
                 /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
             );
             expect(response).toHaveProperty(

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -6,7 +6,7 @@ export class AppController {
     constructor(private readonly appService: AppService) {}
 
     @Get()
-    getHello(): { email: string; current_time: string; github_url: string } {
+    getHello(): { email: string; current_datetime: string; github_url: string } {
         return this.appService.getHello();
     }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -2,11 +2,11 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class AppService {
-    getHello(): { email: string; current_time: string; github_url: string } {
-        const current_time = new Date().toISOString().split('.')[0] + 'Z';
+    getHello(): { email: string; current_datetime: string; github_url: string } {
+        const current_datetime = new Date().toISOString().split('.')[0] + 'Z';
         return {
             email: 'stationphast@gmail.com',
-            current_time,
+            current_datetime,
             github_url: 'https://github.com/Phastboy/first_hng_task',
         };
     }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -25,8 +25,8 @@ describe('AppController (e2e)', () => {
                     'email',
                     'stationphast@gmail.com',
                 );
-                expect(res.body).toHaveProperty('current_time');
-                expect(res.body.current_time).toMatch(
+                expect(res.body).toHaveProperty('current_datetime');
+                expect(res.body.current_datetime).toMatch(
                     /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/,
                 );
                 expect(res.body).toHaveProperty(


### PR DESCRIPTION
This pull request includes changes to the `AppController` and `AppService` classes, as well as their corresponding test files, to rename the `current_time` property to `current_datetime`. This ensures consistency in naming conventions across the codebase.

Changes to property naming:

* [`src/app.controller.ts`](diffhunk://#diff-ef0ff0ca9442bda67ad0810654d636991173ecd7c1abcd6da09288b8815759ffL9-R9): Renamed the `current_time` property to `current_datetime` in the return type of the `getHello` method.
* [`src/app.service.ts`](diffhunk://#diff-a4ac7efdbcfcdcc01a90d433ec3dabf1d88ab4bffbe3dc88f13db54db2e051f5L5-R9): Updated the `getHello` method to use `current_datetime` instead of `current_time` and adjusted the property assignment accordingly.

Updates to tests:

* [`src/app.controller.spec.ts`](diffhunk://#diff-bbc8b4e9f8b329f999b013aaedf36a1db25e79e7020f73125dd7d3e75ae27161L21-R22): Modified the test to check for `current_datetime` instead of `current_time` in the response object.
* [`test/app.e2e-spec.ts`](diffhunk://#diff-07ba1bf8da11808769647b7432dec5d598253fc945127dedb101c705f6343034L28-R29): Updated the end-to-end test to verify the presence and format of `current_datetime` instead of `current_time`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/first_hng_task/pull/18?shareId=db4c03b7-44b3-4d50-8f11-d47a3d167713).